### PR TITLE
Do not log empty meta object

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -15,12 +15,15 @@ module.exports = {
                 metaAsString = options.meta;
             } else if (options.meta instanceof Error && options.meta.stack) {
                 metaAsString = util.inspect(options.meta.stack);
-            }
-            else {
+            } else if (Object.keys(options.meta).length == 0){
+                    metaAsString = '';
+            } else {
                 metaAsString = util.inspect(options.meta);
             }
 
-            returnString = `${returnString} : ${metaAsString}`;
+            if (metaAsString.length > 0){
+                returnString = `${returnString} : ${metaAsString}`;
+            }
         }
         return returnString;
     }

--- a/test/lib/utilsSpec.js
+++ b/test/lib/utilsSpec.js
@@ -61,6 +61,18 @@ describe('utils', function () {
                 expect(formatted).to.equal(expectedLog);
 
             });
+            it('should not log an empty object', function () {
+
+                options.meta = {};
+                var expectedLog = `warning: ${dateString} [unit-tests] lorem`;
+
+                // Act
+                var formatted = loggerUtils.formatter(options);
+
+                // Assert
+                expect(formatted).to.equal(expectedLog);
+
+            });
 
             it('should log a plain object', function () {
                 // Arrange


### PR DESCRIPTION
This change fixes #1.  rtp-logger will now not output any meta string
if an empty object is supplied.
