### PR TITLE
Log format changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: node_js
 before_install:
   - npm i -g npm@5
 node_js:
-- '4'
-- '5'
 - '6'
 deploy:
   provider: npm

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,8 +2,7 @@ var util = require('util');
 
 module.exports = {
     timestamp: function() {
-        var currentDate = new Date().toISOString();
-        return currentDate.substring(0, 10) + ' ' + currentDate.substring(11, 19);
+        return new Date().toISOString()
     },
     formatter: function(options) {
         var metaAsString;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,7 +6,7 @@ module.exports = {
     },
     formatter: function(options) {
         var metaAsString;
-        var returnString =  `${options.level}: ${options.timestamp()} [${options.label}] ${options.message}`;
+        var returnString =  `[${options.label}] [${options.level}] ${options.timestamp()} ${options.message}`;
 
         if(options.meta) {
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rtp-logger",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "Registered traveller programme logger",
   "author": "UK Home Office Registered Traveller Team",
   "license": "MIT",

--- a/test/lib/indexSpec.js
+++ b/test/lib/indexSpec.js
@@ -43,21 +43,30 @@ describe('Logger', function() {
 
             ['debug', 'info', 'warn'].forEach(function (level) {
                 it(level + ' should log to the console via stdout', function() {
-                    logger[level]('test log message');
+                    let msg = 'test log message';
+                    logger[level](msg);
                     stdMocks.restore();
                     var output = stdMocks.flush();
                     expect(output.stdout.length).to.equal(1);
-                    var re = new RegExp(level + ': [0-9-]{10} [0-9:]{8} \\[not-set\\] test log message');
+                    var re = new RegExp([`\\[not-set]`,
+                            `\\[${level}]`,
+                            '\\d\{4\}-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\d(\\.\\d+)?((\[+-\]\\d\\d:\\d\\d)|Z)\?',
+                            msg].join(' '));
                     expect(output.stdout[0]).to.match(re);
                 });
             });
 
             it('error should log to the console via stderr', function() {
-                logger.error('test log message');
+                let msg = 'test log message';
+                logger.error(msg);
                 stdMocks.restore();
                 var output = stdMocks.flush();
                 expect(output.stderr.length).to.equal(1);
-                expect(output.stderr[0]).to.match(/error: [0-9-]{10} [0-9:]{8} \[not-set\] test log message/);
+                var re = new RegExp([`\\[not-set]`,
+                    '\\[error]',
+                    '\\d\{4\}-\\d\{2\}-\\d\{2\}T\\d\{2\}:\\d\{2\}:\\d\{2\}(\\.\\d+)?((\[+-\]\\d\{2\}:\\d\{2\})|Z)\?',
+                    msg].join(' '));
+                expect(output.stderr[0]).to.match(re);
             });
 
             it('should log objects', function() {
@@ -146,11 +155,17 @@ describe('Logger', function() {
                         appName: 'TEST-APP'
                     });
                     stdMocks.use();
-                    logger.info('test log entry');
+                    let msg = 'test log entry';
+                    logger.info(msg);
                     stdMocks.restore();
                     var output = stdMocks.flush();
                     expect(output.stdout.length).to.equal(1);
-                    expect(output.stdout[0]).to.match(/info: [0-9-]{10} [0-9:]{8} \[TEST-APP\] test log entry/);
+                    var re = new RegExp([`\\[TEST-APP]`,
+                        `\\[info]`,
+                        '\\d\{4\}-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\d(\\.\\d+)?((\[+-\]\\d\\d:\\d\\d)|Z)\?',
+                        msg].join(' '));
+
+                    expect(output.stdout[0]).to.match(re);
                 });
 
             });

--- a/test/lib/utilsSpec.js
+++ b/test/lib/utilsSpec.js
@@ -29,7 +29,7 @@ describe('utils', function () {
                 timestamp: timestamp,
                 message: 'lorem'
             };
-            var expectedLog = `${options.level}: ${dateString} [${options.label}] ${options.message}`;
+            var expectedLog = `[${options.label}] [${options.level}] ${dateString} ${options.message}`;
 
             // Act
             var formatted = loggerUtils.formatter(options);
@@ -52,7 +52,7 @@ describe('utils', function () {
 
             it('should log a simple value', function () {
                 options.meta = 'StringValue';
-                var expectedLog = `warning: ${dateString} [unit-tests] lorem : StringValue`;
+                var expectedLog = `[unit-tests] [warning] ${dateString} lorem : StringValue`;
 
                 // Act
                 var formatted = loggerUtils.formatter(options);
@@ -64,7 +64,7 @@ describe('utils', function () {
             it('should not log an empty object', function () {
 
                 options.meta = {};
-                var expectedLog = `warning: ${dateString} [unit-tests] lorem`;
+                var expectedLog = `[unit-tests] [warning] ${dateString} lorem`;
 
                 // Act
                 var formatted = loggerUtils.formatter(options);
@@ -77,7 +77,7 @@ describe('utils', function () {
             it('should log a plain object', function () {
                 // Arrange
                 options.meta = {'key': 'value'};
-                var expectedLog = `warning: ${dateString} [unit-tests] lorem : { key: 'value' }`;
+                var expectedLog = `[unit-tests] [warning] ${dateString} lorem : { key: 'value' }`;
 
                 // Act
                 var formatted = loggerUtils.formatter(options);
@@ -93,7 +93,7 @@ describe('utils', function () {
                 options.meta.root = options.meta;
 
                 var metaAsString = "{ key: 'value', root: [Circular] }";
-                var expectedLog = `warning: ${dateString} [unit-tests] lorem : ${metaAsString}`;
+                var expectedLog = `[unit-tests] [warning] ${dateString} lorem : ${metaAsString}`;
 
                 // Act
                 var formatted = loggerUtils.formatter(options);
@@ -115,7 +115,7 @@ describe('utils', function () {
                 options.meta.beta = beta;
 
                 var metaAsString = `{ key: \'value\',\n  alpha: { link: { link: [Circular] } },\n  beta: { link: { link: [Circular] } } }`;
-                var expectedLog = `warning: ${dateString} [unit-tests] lorem : ${metaAsString}`;
+                var expectedLog = `[unit-tests] [warning] ${dateString} lorem : ${metaAsString}`;
 
                 // Act
                 var formatted = loggerUtils.formatter(options);
@@ -136,7 +136,7 @@ describe('utils', function () {
                     };
 
                     var metaAsString = `{ [Error: ENOENT: no such file or directory, open \'notexistantfile\']\n  errno: -2,\n  code: \'ENOENT\',\n  syscall: \'open\',\n  path: \'notexistantfile\' }`;
-                    var expectedLog = `warning: ${dateString} [unit-tests] lorem : ${metaAsString}`;
+                    var expectedLog = `[unit-tests] [warning] ${dateString} lorem : ${metaAsString}`;
 
                     // Act
                     var formatted = loggerUtils.formatter(options);


### PR DESCRIPTION
Alter log message format to comply with our standard format.
- Logstash needs the format '[Application] [leve] ISODateTime message'.
- Adding other formats causes logstash to slow to unusable and crash.
- Updated tests to reflect new format.